### PR TITLE
fix TRY_OK and TRY_SOME with rvalue-ref argument

### DIFF
--- a/include/stx/internal/try.h
+++ b/include/stx/internal/try.h
@@ -76,10 +76,12 @@ STX_END_NAMESPACE
   decltype((result_expr))&& STX_ARG_UNIQUE_PLACEHOLDER = (result_expr);        \
                                                                                \
   if (STX_ARG_UNIQUE_PLACEHOLDER.is_err())                                     \
-    return ::stx::Err<decltype((result_expr))::error_type>(                    \
+    return ::stx::Err<                                                         \
+      typename std::remove_reference_t<decltype((result_expr))>::error_type>(  \
         ::stx::internal::result::unsafe_err_move(STX_ARG_UNIQUE_PLACEHOLDER)); \
                                                                                \
-  typename decltype((result_expr))::value_type qualifier_identifier =          \
+  typename std::remove_reference_t<decltype((result_expr))>::value_type        \
+    qualifier_identifier =                                                     \
       ::stx::internal::result::unsafe_value_move(STX_ARG_UNIQUE_PLACEHOLDER);
 
 #define STX_TRY_SOME_IMPL_(STX_ARG_UNIQUE_PLACEHOLDER, qualifier_identifier, \
@@ -96,7 +98,8 @@ STX_END_NAMESPACE
                                                                              \
   if (STX_ARG_UNIQUE_PLACEHOLDER.is_none()) return ::stx::None;              \
                                                                              \
-  typename decltype((option_expr))::value_type qualifier_identifier =        \
+  typename std::remove_reference_t<decltype((option_expr))>::value_type      \
+    qualifier_identifier =                                                   \
       ::stx::internal::option::unsafe_value_move(STX_ARG_UNIQUE_PLACEHOLDER);
 
 /// if `result_expr` is a `Result` containing an error, `TRY_OK` returns its

--- a/tests/option_test.cc
+++ b/tests/option_test.cc
@@ -728,6 +728,8 @@ auto opt_try_b(int x) -> Option<int> {
 auto opt_try_a(int m) -> Option<int> {
   // clang-format off
   TRY_SOME(x, opt_try_b(m)); TRY_SOME(const y, opt_try_b(m)); TRY_SOME(volatile z, opt_try_b(m));
+  auto opt = opt_try_b(m);
+  TRY_SOME(w, std::move(opt));
   // clang-format on
   x += 60;
   return Some(std::move(x));

--- a/tests/result_test.cc
+++ b/tests/result_test.cc
@@ -694,6 +694,8 @@ auto ok_try_b(int x) -> stx::Result<int, int> {
 auto ok_try_a(int m) -> stx::Result<int, int> {
   // clang-format off
   TRY_OK(x, ok_try_b(m)); TRY_OK(const y, ok_try_b(m)); TRY_OK(volatile z, ok_try_b(m)); // also tests for name collision in our macros
+  auto result = ok_try_b(m);
+  TRY_OK(w, std::move(result));
   // clang-format on
   x += 60;
   return Ok(std::move(x));


### PR DESCRIPTION
Fix error described in #20 by using `std::remove_reference_t<decltype((result_expr))>`

Also adds a few lines to the Option and Result tests to make sure this scenario is covered.