### PR TITLE
ambiguous overloads with Span function parameters

### DIFF
--- a/tests/span_test.cc
+++ b/tests/span_test.cc
@@ -242,7 +242,7 @@ TEST(SpanTest, Empty) {
     EXPECT_TRUE(a.empty());
   }
   {
-    Span<int> a(tmp, 0UL);
+    Span<int> a(tmp, std::size_t{0});
     EXPECT_TRUE(a.empty());
   }
 }


### PR DESCRIPTION
I started out trying to fix #22 and noticed there are also other, undesirable conversions that are currently allowed (see #23).

This PR is my attempt at fixing both,
by adding SFINAE constraints (and a few non-template iterator/pointer overloads) to the constructors.

I also added these constraints to the try_init factory functions where applicable,
though they could conceivably be replaced with static_asserts there.

I tried to keep the formatting consistent when I had to spread the enable_if conditions over multiple lines,
I'm not sure if I succeeded everywhere.