### PR TITLE
propagate triviality, extend constexpr

### DIFF
--- a/include/stx/config.h
+++ b/include/stx/config.h
@@ -214,6 +214,14 @@
 #define STX_HAS_BUILTIN(feature) 0
 #endif
 
+#if defined STX_ENABLE_DEBUG_ASSERTIONS
+#define STX_DEBUG_ASSERT(Cond) (Cond) ? (void)0 : (void)(::stx::panic(#Cond))
+#define STX_DEBUG_STATEMENT(...) __VA_ARGS__
+#else
+#define STX_DEBUG_ASSERT(Cond) (void)0
+#define STX_DEBUG_STATEMENT(...) (void)0
+#endif
+
 // From non-trivial constexpr paper
 #if __cpp_constexpr >= 201807L
 

--- a/include/stx/internal/option_result.h
+++ b/include/stx/internal/option_result.h
@@ -449,7 +449,7 @@ struct Setter {
   constexpr void operator()() noexcept { ref = value; }
 };
 
-template <typename T, bool = std::is_trivial_v<T> && constructible<T>>
+template <typename T, bool = std::is_trivial_v<T> && nothrow_constructible<T>>
 struct OptionStorageBase {
 private:
   T storage_value_{};
@@ -536,7 +536,7 @@ struct OptionStorageBasePre<T, false> {
       static_cast<OptionStorageBase<T>&>(*this)._destroy();
     }
   }
-  constexpr OptionStorageBasePre(){};
+  constexpr OptionStorageBasePre() noexcept {};
   template <typename U>
   constexpr OptionStorageBasePre(U&& val) noexcept(
       nothrow_constructible<T, decltype((std::declval<U&&>().value_))>)
@@ -802,7 +802,7 @@ public:
       "type wrappers like std::reference_wrapper (stx::Ref) or any of the "
       "`stx::ConstRef` or `stx::MutRef` specialized aliases instead");
 
-  constexpr Option() noexcept = default;
+  constexpr Option() = default;
 
   using internal::option::OptionMoveAssignBase<T>::OptionMoveAssignBase;
 


### PR DESCRIPTION
this is a bit of a big PR since a bunch of changes were coupled. my intention was to just extend constexpr support and that required more machinery until i ended up with something that mirrors the standard's `optional<T>` (as well as most high quality `optional` implementations)

`Option<T>` is now trivially copy/move constructible/assignable, and/or trivially the destructible when the same is true for `T`. which makes those operations `constexpr` in c++17. when all of those are trivial, the optional is trivially copyable, which allows a good amount of compiler optimizations. (e.g. [with trivial copyability](https://godbolt.org/z/33Y4ze), calls malloc or uses vectorized instructions. [without trivial copyability](https://godbolt.org/z/sfrc6q), copies the data one by one)

in c++20 they can always be constexpr, by using `std::construct_at` instead of placement `new`

additionally, when the type `T` is trivial and default constructible, we store `Option<T>` as a `T`+`bool`, instead of a tagged union. this allows all operations to be `constexpr`.

the same optimizations can be applied to `Result<T, E>`, but i thought i'd get some feedback before i go ahead with that