### PR TITLE
Fixed GNU compiler warnings

### DIFF
--- a/include/stx/fn.h
+++ b/include/stx/fn.h
@@ -170,7 +170,7 @@ template <typename T, typename Stub = void>
 struct is_functor_impl : public std::false_type {};
 
 template <typename T>
-struct is_functor_impl<T, decltype(&T::operator(), (void)0)>
+struct is_functor_impl<T, decltype((void)0)>
     : public std::true_type {};
 
 template <typename T>

--- a/include/stx/option.h
+++ b/include/stx/option.h
@@ -667,7 +667,7 @@ struct [[nodiscard]] Option : impl::check_value_type<T>,
     if (is_some()) {
       Some some = std::move(some_);
       storage::assign(None);
-      return std::move(some);
+      return some;
     } else {
       return None;
     }

--- a/include/stx/vec.h
+++ b/include/stx/vec.h
@@ -20,8 +20,7 @@ enum class VecError : uint8_t { OutOfMemory };
 namespace impl {
 template <typename T>
 constexpr void destruct_range(T* start, size_t size) {
-  if constexpr (std::is_trivially_destructible_v<T>) {
-  } else {
+  if constexpr (!std::is_trivially_destructible_v<T>) {
     for (T& element : Span<T>{start, size}) {
       element.~T();
     }


### PR DESCRIPTION
- returning with std::move has no effect as `some` is already a temporary object

https://github.com/lamarrr/STX/blob/822cf2ac1fd43ab62aa9fdfd961310381bf831fe/include/stx/option.h#L666-L670

- using `decltype((void))`   serves the same purpose of indicating that the type T has an operator() member function.

https://github.com/lamarrr/STX/blob/822cf2ac1fd43ab62aa9fdfd961310381bf831fe/include/stx/fn.h#L173-L174

- No need to have an empty `if` block

https://github.com/lamarrr/STX/blob/822cf2ac1fd43ab62aa9fdfd961310381bf831fe/include/stx/vec.h#L23-L25
