### PR TITLE
panic: set ReportQuery buffer size

### DIFF
--- a/include/stx/panic.h
+++ b/include/stx/panic.h
@@ -49,7 +49,7 @@ template <typename T>
     SourceLocation location = SourceLocation::current())
 {
   char buffer[256];
-  auto error_report = ReportQuery{buffer} >> value;
+  auto error_report = ReportQuery{buffer, std::size(buffer)} >> value;
 
   begin_panic(info, error_report, location);
 }


### PR DESCRIPTION
`stx::panic(std::string_view info, T const &value)` does not set the buffer size,
so `value` is never stringified because there appears to be no room in the buffer.

This PR just sets the buffer size, same as the tests do.